### PR TITLE
#7 feat: application-db.properties 파일 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+application-db.properties

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=gc-coffee
+spring.profiles.include=db


### PR DESCRIPTION

## 📌 과제 설명
application-db.properties 파일이 gitignore에 들어갈 수 있도록 설정

## 👩‍💻 요구 사항과 구현 내용 
1. gitignore 파일에 application-db.properties 추가
2. 기존 application-properties 파일에 application-db.properties 파일 포함시키도록 코드 추가