### PR TITLE
Feat/#28 주문요청기능추가

### DIFF
--- a/src/main/java/com/example/gc_coffee/controller/OrderController.java
+++ b/src/main/java/com/example/gc_coffee/controller/OrderController.java
@@ -2,9 +2,11 @@ package com.example.gc_coffee.controller;
 
 import com.example.gc_coffee.common.ApiResponse;
 import com.example.gc_coffee.dto.request.OrderCreateRequest;
+import com.example.gc_coffee.dto.response.OrderResponse;
 import com.example.gc_coffee.service.OrderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,8 +20,8 @@ public class OrderController {
     private final OrderService orderService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse> register(@RequestBody OrderCreateRequest orderCreateRequest) {
-        orderService.register(orderCreateRequest);
-        return ResponseEntity.ok(ApiResponse.success(null));
+    public ResponseEntity<ApiResponse> register(@Validated @RequestBody OrderCreateRequest orderCreateRequest) {
+        OrderResponse orderResponse = orderService.register(orderCreateRequest);
+        return ResponseEntity.ok(ApiResponse.success(orderResponse));
     }
 }

--- a/src/main/java/com/example/gc_coffee/dto/request/OrderCreateRequest.java
+++ b/src/main/java/com/example/gc_coffee/dto/request/OrderCreateRequest.java
@@ -1,9 +1,13 @@
 package com.example.gc_coffee.dto.request;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.List;
 
@@ -11,9 +15,18 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
+@Validated
 public class OrderCreateRequest {
+    @NotBlank(message = "Email은 비어있을 수 없습니다.")
+    @Email(message = "유효한 이메일 형식이 아닙니다.")
     private String email;
+
+    @NotBlank(message = "주소는 비어있을 수 없습니다.")
     private String address;
+
+    @NotBlank(message = "우편번호는 비어있을 수 없습니다.")
     private String postcode;
+
+    @NotEmpty(message = "주문 항목은 비어있을 수 없습니다.")
     private List<OrderItemCreateRequest> orderItems;
 }

--- a/src/main/java/com/example/gc_coffee/dto/request/OrderItemCreateRequest.java
+++ b/src/main/java/com/example/gc_coffee/dto/request/OrderItemCreateRequest.java
@@ -1,6 +1,8 @@
 package com.example.gc_coffee.dto.request;
 
 import com.example.gc_coffee.entity.ProductCategory;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,8 +13,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Data
 public class OrderItemCreateRequest {
+    @NotNull(message = "상품 ID는 비어있을 수 없습니다.")
     private Long productId;
+
+    @NotNull(message = "카테고리는 비어있을 수 없습니다.")
     private ProductCategory category;
+
+    @Min(value = 0, message = "가격은 0 이상이어야 합니다.")
     private int price;
+
+    @Min(value = 1, message = "수량은 1 이상이어야 합니다.")
     private int quantity;
 }

--- a/src/main/java/com/example/gc_coffee/dto/response/OrderResponse.java
+++ b/src/main/java/com/example/gc_coffee/dto/response/OrderResponse.java
@@ -1,14 +1,10 @@
 package com.example.gc_coffee.dto.response;
 
 import com.example.gc_coffee.entity.Order;
-import com.example.gc_coffee.entity.OrderItem;
 import com.example.gc_coffee.entity.OrderStatus;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Data
 public class OrderResponse {

--- a/src/main/java/com/example/gc_coffee/dto/response/OrderResponse.java
+++ b/src/main/java/com/example/gc_coffee/dto/response/OrderResponse.java
@@ -1,0 +1,31 @@
+package com.example.gc_coffee.dto.response;
+
+import com.example.gc_coffee.entity.Order;
+import com.example.gc_coffee.entity.OrderItem;
+import com.example.gc_coffee.entity.OrderStatus;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+public class OrderResponse {
+
+    private Long orderId;
+    private String email;
+    private String address;
+    private String postcode;
+    private OrderStatus orderStatus;
+    private LocalDateTime createdAt;
+
+    public OrderResponse(Order order) {
+        this.orderId = order.getOrderId();
+        this.email = order.getEmail();
+        this.address = order.getAddress();
+        this.postcode = order.getPostcode();
+        this.orderStatus = order.getOrderStatus();
+        this.createdAt = order.getCreatedAt();
+    }
+}

--- a/src/main/java/com/example/gc_coffee/exception/OrderException.java
+++ b/src/main/java/com/example/gc_coffee/exception/OrderException.java
@@ -1,0 +1,20 @@
+package com.example.gc_coffee.exception;
+
+public enum OrderException {
+    NOT_FOUND("Order NOT FOUND", 404),
+    CREATION_FAILED("Order CREATION FAILED", 400),
+    REMOVAL_FAILED("Order REMOVAL FAILED", 400),
+    UPDATE_FAILED("Order UPDATE FAILED", 500),
+    ITEM_NOT_FOUND("Order ITEM NOT FOUND", 404);
+
+
+    private final OrderTaskException orderTaskException;
+
+    OrderException(String message, int code) {
+        this.orderTaskException = new OrderTaskException(message, code);
+    }
+
+    public OrderTaskException get() {
+        return orderTaskException;
+    }
+}

--- a/src/main/java/com/example/gc_coffee/exception/OrderTaskException.java
+++ b/src/main/java/com/example/gc_coffee/exception/OrderTaskException.java
@@ -1,0 +1,11 @@
+package com.example.gc_coffee.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OrderTaskException extends RuntimeException{
+    private  String message;
+    private  int code;
+}

--- a/src/main/java/com/example/gc_coffee/service/OrderService.java
+++ b/src/main/java/com/example/gc_coffee/service/OrderService.java
@@ -2,11 +2,13 @@ package com.example.gc_coffee.service;
 
 import com.example.gc_coffee.dto.request.OrderCreateRequest;
 import com.example.gc_coffee.dto.request.OrderItemCreateRequest;
+import com.example.gc_coffee.dto.response.OrderResponse;
 import com.example.gc_coffee.entity.Order;
 import com.example.gc_coffee.entity.OrderItem;
 import com.example.gc_coffee.entity.OrderStatus;
 import com.example.gc_coffee.entity.Product;
-import com.example.gc_coffee.repository.OrderItemRepository;
+import com.example.gc_coffee.exception.OrderException;
+import com.example.gc_coffee.exception.ProductException;
 import com.example.gc_coffee.repository.OrderRepository;
 import com.example.gc_coffee.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,29 +27,27 @@ public class OrderService {
 
     private final ProductRepository productRepository;
     private final OrderRepository orderRepository;
-    private final OrderItemRepository orderItemRepository;
 
-    public void register(OrderCreateRequest orderCreateRequest) {
+    public OrderResponse register(OrderCreateRequest orderCreateRequest) {
         //주문 시간이 오후 2시 이후면 orderStatus 를 CONFIRMED 로 설정.
         LocalTime now = LocalTime.now();
         LocalTime cutoffTime = LocalTime.of(14, 0);
 
         OrderStatus orderStatus = now.isAfter(cutoffTime) ? OrderStatus.CONFIRMED : OrderStatus.SHIPPED;
 
-        //email 로 Order 검색 -> 처음 주문하는 고객이면 Order 생성
-        Order order = orderRepository.findByEmail(orderCreateRequest.getEmail())
-                .orElseGet(() -> orderRepository.save(Order.builder()
-                            .email(orderCreateRequest.getEmail())
-                            .address(orderCreateRequest.getAddress())
-                            .postcode(orderCreateRequest.getPostcode())
-                            .orderStatus(orderStatus)
-                            .orderItems(new ArrayList<>())
-                            .build()));
+        //Order 객체 생성
+        Order order = Order.builder()
+                .email(orderCreateRequest.getEmail())
+                .address(orderCreateRequest.getAddress())
+                .postcode(orderCreateRequest.getPostcode())
+                .orderStatus(orderStatus)
+                .orderItems(new ArrayList<>())
+                .build();
 
-        //OrderItem(Product, Order 정보 필요) 객체 생성 후 저장
+        //OrderItem(Product, Order 정보 필요) 객체 생성 및 저장
         for (OrderItemCreateRequest orderItemCreateRequest : orderCreateRequest.getOrderItems()) {
             Product product = productRepository.findById(orderItemCreateRequest.getProductId())
-                    .orElseThrow(RuntimeException::new);
+                    .orElseThrow(ProductException.NOT_FOUND::get);
 
             OrderItem orderItem = OrderItem.builder()
                     .product(product)
@@ -57,10 +57,15 @@ public class OrderService {
                     .quantity(orderItemCreateRequest.getQuantity())
                     .build();
 
-            orderItemRepository.save(orderItem);
             order.getOrderItems().add(orderItem);
         }
 
-        orderRepository.save(order);
+        //Order 및 OrderItem 저장
+        try {
+            Order saved = orderRepository.save(order);
+            return new OrderResponse(saved);
+        } catch (Exception e) {
+            throw OrderException.CREATION_FAILED.get();
+        }
     }
 }

--- a/src/main/java/com/example/gc_coffee/service/OrderService.java
+++ b/src/main/java/com/example/gc_coffee/service/OrderService.java
@@ -52,8 +52,8 @@ public class OrderService {
             OrderItem orderItem = OrderItem.builder()
                     .product(product)
                     .order(order)
-                    .category(orderItemCreateRequest.getCategory())
-                    .price(orderItemCreateRequest.getPrice())
+                    .category(product.getProductCategory())
+                    .price(product.getPrice())
                     .quantity(orderItemCreateRequest.getQuantity())
                     .build();
 


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
주문 생성 로직에 기능 추가

### 📌주문 요청 로직 흐름 설명
1. 고객이 자신의 정보와 함께 주문할 상품들을 요청
2. 요청 받은 고객의 정보를 이용해 **Order객체 생성** { email, address, postcode, orderStatus, orderItems(비어있음) }
3. 이때 orderStatus는 2시 이전이라면 `SHIPPED`,  2시 이후라면 `CONFIRMED`로 설정
4. 요청 받은 주문 상품의 productId를 이용해 **Product객체 찾기** (id, productName, productCategory, price, description, ...)
5. 2번에서 생성한 Order객체와 4번에서 찾은 Product를 이용해서 **OrderItem 객체 생성** (orderItemId, product, order, category, price, quantity) *quantity는 요청 받은 수량으로 설정
6. 생성된 **OrderItem 객체를 Order 객체의 orderItems필드에 추가**
7. 4~6번을 주문한 상품 개수만큼 반복
8. **Order 객체, OrderItem 객체 저장**
9. OrderResponseDTO 반환

![image](https://github.com/user-attachments/assets/e6d133e0-8a54-4583-ab91-f59094945d95)
![image](https://github.com/user-attachments/assets/4602c98b-d580-4d43-af57-2e87f6ee8e97)


## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 주문 요청 **DTO에 validation** 적용
  - OrderCreateRequest, OrderItemCreateRequest에 validation 어노테이션 추가
 
- **OrderResponse** 생성 
  - 주문 요청 시 반환되는 DTO
 
- OrderService에 ****예외처리 적용 & 반환타입** 변경**
  - 주문하려는 Product가 없을 시 `ProductEXCEPTION.NOT_FOUND` 예외 반환
  - void에서 OrderResponse를 반환하도록 변경

- 주문 요청 컨트롤러에 `@Validated` 적용 & 반환 객체 변경
  - OrderCreateRequest에 @Validated 추가
  - OrderService에서 반환하는 OrderResponse를 data로 반환
