### PR TITLE
Feat/#40/주문관리의 주문조회 기능 구현

### DIFF
--- a/src/main/java/com/example/gc_coffee/controller/OrderItemController.java
+++ b/src/main/java/com/example/gc_coffee/controller/OrderItemController.java
@@ -16,8 +16,8 @@ public class OrderItemController {
     private OrderItemService orderItemService;
 
     @GetMapping
-    public ResponseEntity<List<OrderItemResponse>> getOrderItemsByStatus() {
-        List<OrderItemResponse> orderItems = orderItemService.getOrderedItems();
+    public ResponseEntity<List<OrderItemResponse>> getOrderItemsByEmail(@RequestParam String email) {
+        List<OrderItemResponse> orderItems = orderItemService.getOrderedItemsByEmail(email);
         if (orderItems.isEmpty()) {
             return ResponseEntity.noContent().build();
         }

--- a/src/main/java/com/example/gc_coffee/controller/OrderItemController.java
+++ b/src/main/java/com/example/gc_coffee/controller/OrderItemController.java
@@ -1,0 +1,26 @@
+package com.example.gc_coffee.controller;
+
+import com.example.gc_coffee.dto.response.OrderItemResponse;
+import com.example.gc_coffee.service.OrderItemService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/orderitem")
+public class OrderItemController {
+
+    @Autowired
+    private OrderItemService orderItemService;
+
+    @GetMapping
+    public ResponseEntity<List<OrderItemResponse>> getOrderItemsByStatus() {
+        List<OrderItemResponse> orderItems = orderItemService.getOrderedItems();
+        if (orderItems.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(orderItems);
+    }
+}

--- a/src/main/java/com/example/gc_coffee/dto/response/OrderItemResponse.java
+++ b/src/main/java/com/example/gc_coffee/dto/response/OrderItemResponse.java
@@ -14,6 +14,7 @@ public class OrderItemResponse {
     private int totalPrice;
 
     private Long orderId;
+    private String productName;
     private String email;
     private String address;
     private String postcode;

--- a/src/main/java/com/example/gc_coffee/dto/response/OrderItemResponse.java
+++ b/src/main/java/com/example/gc_coffee/dto/response/OrderItemResponse.java
@@ -1,5 +1,6 @@
 package com.example.gc_coffee.dto.response;
 
+import com.example.gc_coffee.entity.OrderStatus;  // OrderStatus 클래스 import
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,4 +12,9 @@ public class OrderItemResponse {
     private int quantity;
     private int price;
     private int totalPrice;
+
+    private Long orderId;
+    private String address;
+    private String postcode;
+    private OrderStatus orderStatus;
 }

--- a/src/main/java/com/example/gc_coffee/dto/response/OrderItemResponse.java
+++ b/src/main/java/com/example/gc_coffee/dto/response/OrderItemResponse.java
@@ -14,7 +14,9 @@ public class OrderItemResponse {
     private int totalPrice;
 
     private Long orderId;
+    private String email;
     private String address;
     private String postcode;
     private OrderStatus orderStatus;
 }
+

--- a/src/main/java/com/example/gc_coffee/repository/OrderItemRepository.java
+++ b/src/main/java/com/example/gc_coffee/repository/OrderItemRepository.java
@@ -1,10 +1,14 @@
 package com.example.gc_coffee.repository;
 
 import com.example.gc_coffee.entity.OrderItem;
+import com.example.gc_coffee.entity.OrderStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
     Optional<OrderItem> findByOrder_OrderId(Long orderId);
+    List<OrderItem> findByOrder_OrderStatus(OrderStatus status);  // 주문 상태에 따른 주문 항목 필터링
+
 }

--- a/src/main/java/com/example/gc_coffee/repository/OrderItemRepository.java
+++ b/src/main/java/com/example/gc_coffee/repository/OrderItemRepository.java
@@ -9,6 +9,5 @@ import java.util.Optional;
 
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
     Optional<OrderItem> findByOrder_OrderId(Long orderId);
-    List<OrderItem> findByOrder_OrderStatus(OrderStatus status);  // 주문 상태에 따른 주문 항목 필터링
-
+    List<OrderItem> findByOrder_OrderStatus(OrderStatus status);
 }

--- a/src/main/java/com/example/gc_coffee/service/OrderItemService.java
+++ b/src/main/java/com/example/gc_coffee/service/OrderItemService.java
@@ -18,24 +18,25 @@ public class OrderItemService {
     @Autowired
     private OrderItemRepository orderItemRepository;
 
-    public List<OrderItemResponse> getOrderedItems() {
-        // 주문 상태가 ORDERED인 항목만 조회
+    public List<OrderItemResponse> getOrderedItemsByEmail(String email) {
         List<OrderItem> orderItems = orderItemRepository.findByOrder_OrderStatus(OrderStatus.ORDERED);
 
-        return orderItems.stream().map(orderItem -> {
-            Order order = orderItem.getOrder();
-            Product product = orderItem.getProduct();
-            return OrderItemResponse.builder()
-                    .orderItemId(orderItem.getOrderItemId())
-                    .productId(orderItem.getProduct().getId())
-                    .quantity(orderItem.getQuantity())
-                    .orderId(order.getOrderId())
-                    .productName(product.getProductName())
-                    .email(order.getEmail())
-                    .address(order.getAddress())
-                    .postcode(order.getPostcode())
-                    .orderStatus(order.getOrderStatus())
-                    .build();
-        }).collect(Collectors.toList());
+        return orderItems.stream()
+                .filter(orderItem -> orderItem.getOrder().getEmail().equals(email))  // 이메일로 필터링
+                .map(orderItem -> {
+                    Order order = orderItem.getOrder();
+                    Product product = orderItem.getProduct();
+                    return OrderItemResponse.builder()
+                            .orderItemId(orderItem.getOrderItemId())
+                            .productId(orderItem.getProduct().getId())
+                            .quantity(orderItem.getQuantity())
+                            .orderId(order.getOrderId())
+                            .productName(product.getProductName())
+                            .email(order.getEmail())
+                            .address(order.getAddress())
+                            .postcode(order.getPostcode())
+                            .orderStatus(order.getOrderStatus())
+                            .build();
+                }).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/gc_coffee/service/OrderItemService.java
+++ b/src/main/java/com/example/gc_coffee/service/OrderItemService.java
@@ -4,6 +4,7 @@ import com.example.gc_coffee.dto.response.OrderItemResponse;
 import com.example.gc_coffee.entity.Order;
 import com.example.gc_coffee.entity.OrderItem;
 import com.example.gc_coffee.entity.OrderStatus;
+import com.example.gc_coffee.entity.Product;
 import com.example.gc_coffee.repository.OrderItemRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -23,11 +24,13 @@ public class OrderItemService {
 
         return orderItems.stream().map(orderItem -> {
             Order order = orderItem.getOrder();
+            Product product = orderItem.getProduct();
             return OrderItemResponse.builder()
                     .orderItemId(orderItem.getOrderItemId())
                     .productId(orderItem.getProduct().getId())
                     .quantity(orderItem.getQuantity())
                     .orderId(order.getOrderId())
+                    .productName(product.getProductName())
                     .email(order.getEmail())
                     .address(order.getAddress())
                     .postcode(order.getPostcode())

--- a/src/main/java/com/example/gc_coffee/service/OrderItemService.java
+++ b/src/main/java/com/example/gc_coffee/service/OrderItemService.java
@@ -1,0 +1,37 @@
+package com.example.gc_coffee.service;
+
+import com.example.gc_coffee.dto.response.OrderItemResponse;
+import com.example.gc_coffee.entity.Order;
+import com.example.gc_coffee.entity.OrderItem;
+import com.example.gc_coffee.entity.OrderStatus;
+import com.example.gc_coffee.repository.OrderItemRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class OrderItemService {
+
+    @Autowired
+    private OrderItemRepository orderItemRepository;
+
+    public List<OrderItemResponse> getOrderedItems() {
+        // 주문 상태가 ORDERED인 항목만 조회
+        List<OrderItem> orderItems = orderItemRepository.findByOrder_OrderStatus(OrderStatus.ORDERED);
+
+        return orderItems.stream().map(orderItem -> {
+            Order order = orderItem.getOrder();
+            return OrderItemResponse.builder()
+                    .orderItemId(orderItem.getOrderItemId())
+                    .productId(orderItem.getProduct().getId())
+                    .quantity(orderItem.getQuantity())
+                    .orderId(order.getOrderId())
+                    .address(order.getAddress())
+                    .postcode(order.getPostcode())
+                    .orderStatus(order.getOrderStatus())
+                    .build();
+        }).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/gc_coffee/service/OrderItemService.java
+++ b/src/main/java/com/example/gc_coffee/service/OrderItemService.java
@@ -28,6 +28,7 @@ public class OrderItemService {
                     .productId(orderItem.getProduct().getId())
                     .quantity(orderItem.getQuantity())
                     .orderId(order.getOrderId())
+                    .email(order.getEmail())
                     .address(order.getAddress())
                     .postcode(order.getPostcode())
                     .orderStatus(order.getOrderStatus())

--- a/src/test/java/com/example/gc_coffee/repository/OrderItemRepositoryTest.java
+++ b/src/test/java/com/example/gc_coffee/repository/OrderItemRepositoryTest.java
@@ -12,6 +12,7 @@ import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.example.gc_coffee.entity.QOrderItem.orderItem;
@@ -61,6 +62,33 @@ public class OrderItemRepositoryTest {
                 .build();
         orderItemRepository.save(orderItem1);
 
+    }
+
+    @Test
+    public void testFindByOrderStatus() {
+        // 상태가 ORDERED인 주문들을 조회
+        OrderStatus status = OrderStatus.ORDERED;
+
+        // 주문 상태가 ORDERED인 항목을 조회
+        List<OrderItem> orderItems = orderItemRepository.findByOrder_OrderStatus(status);
+
+        // 조회된 항목이 비어 있지 않음을 확인하고 주문 정보를 검증
+        assertThat(orderItems).isNotEmpty();
+
+        orderItems.forEach(orderItem -> {
+            Order order = orderItem.getOrder();
+            System.out.println("주문번호: " + order.getOrderId());
+            System.out.println("이메일: " + order.getEmail());
+            System.out.println("주소: " + order.getAddress());
+            System.out.println("우편번호: " + order.getPostcode());
+            System.out.println("배송 상태: " + order.getOrderStatus());
+
+            // 검증
+            assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.ORDERED);
+            assertThat(order.getEmail()).isNotNull();
+            assertThat(order.getAddress()).isNotNull();
+            assertThat(order.getPostcode()).isNotNull();
+        });
     }
 
     @Test


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
주문 후 주문 목록 조회하는 기능 구현

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
주문 후 같은 이메일 사용자의 ORDER상태인 주문 목록(주문번호, 이메일, 우편번호, 주소, 주문상태)을 조회한다.
![1](https://github.com/user-attachments/assets/8f47ce2c-3e4d-4723-a79f-4662a7aba408)
![2](https://github.com/user-attachments/assets/a64af071-9eda-4863-8ae2-5d83af79b952)

! 조회 시 가격 부분은 order부분과 연관되어 있어서 같이 조회가 되며 추후 전체 파일 수정하거나 front에서 작업 시 작업하지 않거나 감추면 좋을 것 같습니다.
